### PR TITLE
fix(docs): Correct syntax in Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ graph TD
         end
         subgraph "Databases"
             E[RDS - PostgreSQL]
-            F[Neo4j (AuraDB)]
+            F[Neo4j - AuraDB]
         end
         G[Cognito]
         H[S3 for Assets]


### PR DESCRIPTION
This PR corrects a syntax error in the `README.md` that was preventing the Mermaid architecture diagram from rendering correctly on GitHub.

**Problem:**
The use of parentheses within the `mermaid` code block was causing the render to fail.

**Solution:**
Replaced the parentheses with a dash.